### PR TITLE
docs: Add workflows to deploy docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+name: Test documentation build
+
+on:
+  pull_request:
+    paths:
+      - '**.py'
+      - '**.ipynb'
+      - '**.rst'
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Run a one-line script
+      run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+    - uses: actions/checkout@v4
+  
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+#    - name: Test with pytest
+#      run: |
+#        pytest
+
+
+#    - name: Setup Micromamba ${{ matrix.python-version }}
+#      uses: mamba-org/setup-micromamba@v2.0.1
+#      with:
+#        environment-name: TEST
+#        init-shell: bash
+#        create-args: >-
+#          python=3 pip
+#          --file requirements-dev.txt
+#          --channel conda-forge
+
+#    - name: Install seagliderOG1
+#      shell: bash -l {0}
+#      run: |
+#        python -m pip install -e . --no-deps --force-reinstall
+
+    # Assumes that the notebook to be documented is located within notebooks/ and is called demo.ipynb
+    # In the example below, we've included the `--ExecutePreprocessor.allow_errors=True` flag to allow the notebook to build even if there are errors
+    # For production runs (and when your code is cleaner), you can remove this flag or set it to False.
+    - name: Build documentation
+      shell: bash -l {0}
+      run: |
+        set -e
+        jupyter nbconvert --to notebook --execute notebooks/demo.ipynb --output=demo-output.ipynb --ExecutePreprocessor.allow_errors=True
+        mv notebooks/*output.ipynb docs/source/
+        pushd docs
+        make clean html 
+        popd

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Run a one-line script
+      run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+  
+#    - name: Setup Micromamba ${{ matrix.python-version }}
+#      uses: mamba-org/setup-micromamba@v2.0.1
+#      with:
+#        environment-name: TEST
+#        init-shell: bash
+#        create-args: >-
+#          python=3 pip
+#          --file requirements-dev.txt
+#          --channel conda-forge
+
+#    - name: Install seagliderOG1
+#      shell: bash -l {0}
+#      run: |
+#        python -m pip install -e . --no-deps --force-reinstall
+
+    - name: Build documentation
+      shell: bash -l {0}
+      run: |
+        set -e
+        jupyter nbconvert --to notebook --execute notebooks/demo.ipynb --output=demo-output.ipynb --ExecutePreprocessor.allow_errors=True
+        mv notebooks/*output.ipynb docs/source/
+        pushd docs
+        make clean html 
+        popd
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/html
+
+


### PR DESCRIPTION
When you'd like to have a "read the docs" style documentation for your coding project, there is a way to do this using `sphinx`.  It will require adding additional packages to your `requirements-dev.txt`: 

```
jupyterlab
nbsphinx
nbconvert
sphinx
sphinx-rtd-theme
```

And will generate documents in the directory `docs/` which contains a `Makefile` for the `make clean html` step in `docs.yml` and `docs_deploy.yml`.  Within `docs/source/` there needs to be a `conf.py` file which is explained here: https://www.sphinx-doc.org/en/master/usage/configuration.html.  Edit the example `conf.py` file to represent your project, including updating the project name, the authors and release, and the logo filename (if needed).  

You can optionally include the `_static/` directory for e.g. images to be included (the name of this directory is specified in the `conf.py` file as `html_static_path = ['_static']`).  

The step `jupyter nbconvert` in `docs.yml` and `docs_deploy.yml` executes the notebook `notebooks/demo.ipynb` into an executed notebook which is then moved into the `docs/source/` directory to be viewable.  Files with endings `*.rst` and `*.md` (as specified in `conf.py`, `source_suffix = [".rst", ".md"]`) are parsed where the `index.rst` specifies what other files to call up and in what order.

To activate the page `https://ifmeo-hamburg.github.io/projectName`, you will additionally need to change settings on `https://github.com/ifmeo-hamburg/projectName` under the "Pages" bar.  Here, you will want the pages to deploy from the branch `gh-pages` (once it exists, after the first successful run of `docs_deploy.yml`).  After it is working, and you can see the docs pages at `https://ifmeo-hamburg.github.io/projectName`, then you can edit the repository settings.