### PR TITLE
[DOCS/FIX] Update method to include markdown in sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,6 @@
 # Configuration file for the Sphinx documentation builder.
 #
-# More information about Sphinx here: https://www.sphinx-doc.org/en/master/usage/configuration.html
+# More information about Sphinx here: https://www.sphinx-doc.org/en/master/usage/index.html
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,7 @@
 # Configuration file for the Sphinx documentation builder.
 #
+# More information about Sphinx here: https://www.sphinx-doc.org/en/master/usage/configuration.html
+#
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
@@ -15,9 +17,24 @@ author = 'FirstName LastName, FirstName LastName'
 copyright = f"{year}, {author}"
 release = 'v0.0.0'
 
+# More complicated example from gliderTools:
+#release = get_distribution("glidertools").version
+#version = ".".join(release.split(".")[:2])
+# The full version, including alpha/beta/rc tags.
+# release = version
+
+# link to github issues
+extlinks = {
+    "issue": ("https://github.com/eleanorfrajka/template-project/issues/%s", "GH#%s"),
+    "pull": ("https://github.com/eleanorfrajka/template-project/issues/%s", "GH#%s"),
+}
+
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
@@ -25,19 +42,208 @@ extensions = [
     "nbsphinx",
 ]
 
-
-
+# Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-exclude_patterns = []
 
+# The suffix of source filenames.
+source_suffix = [".rst", ".md"]
 
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+exclude_patterns = ["_build"]
+
+# If true, '()' will be appended to :func: etc. cross-reference text.
+add_function_parentheses = True
+
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+# add_module_names = True
+
+# If true, sectionauthor and moduleauthor directives will be shown in the
+# output. They are ignored by default.
+# show_authors = False
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = "sphinx"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-source_suffix = [".rst", ".md"]
-
+# The name of an image file (relative to this directory) to place at the top
+# of the sidebar.
 html_logo = "_static/logo.jpg"
+
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+# html_theme_options = {
+#     "logo_only": True,
+#     "display_version": False,
+#     "style_nav_header_background": "#343131",
+# }
+# Add any paths that contain custom themes here, relative to this directory.
+# html_theme_path = []
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+# html_title = None
+
+# A shorter title for the navigation bar.  Default is the same as html_title.
+# html_short_title = None
+
+# Add any extra paths that contain custom files (such as robots.txt or
+# .htaccess) here, relative to this directory. These files are copied
+# directly to the root of the documentation.
+# html_extra_path = []
+
+# custom CSS files
+# html_context = {
+#    "css_files": ["_static/css/custom.css"],
+# }
+
+# The name of an image file (within the static path) to use as favicon of the
+# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
+# pixels large.
+# html_favicon = None
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
+# using the given strftime format.
+# html_last_updated_fmt = '%b %d, %Y'
+
+# If true, SmartyPants will be used to convert quotes and dashes to
+# typographically correct entities.
+# html_use_smartypants = True
+
+# Custom sidebar templates, maps document names to template names.
+# html_sidebars = {}
+
+# Additional templates that should be rendered to pages, maps page names to
+# template names.
+# html_additional_pages = {}
+
+# If false, no module index is generated.
+# html_domain_indices = True
+
+# If false, no index is generated.
+# html_use_index = True
+
+# If true, the index is split into individual pages for each letter.
+# html_split_index = False
+html_split_index = True
+
+# If true, links to the reST sources are added to the pages.
+# html_show_sourcelink = True
+
+# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
+# html_show_sphinx = True
+
+# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
+# html_show_copyright = True
+
+# If true, an OpenSearch description file will be output, and all pages will
+# contain a <link> tag referring to it.  The value of this option must be the
+# base URL from which the finished HTML is served.
+# html_use_opensearch = ''
+
+# This is the file name suffix for HTML files (e.g. ".xhtml").
+# html_file_suffix = None
+
+# -- Options for LaTeX output ---------------------------------------------
+
+latex_elements = {
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
+}
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title,
+#  author, documentclass [howto, manual, or own class]).
+latex_documents = [
+    (
+        "index",
+        "ReadtheDocsTemplate.tex",
+        "Read the Docs Template Documentation",
+        "Read the Docs",
+        "manual",
+    ),
+]
+
+# The name of an image file (relative to this directory) to place at the top of
+# the title page.
+# latex_logo = None
+
+# For "manual" documents, if this is true, then toplevel headings are parts,
+# not chapters.
+# latex_use_parts = False
+
+# If true, show page references after internal links.
+# latex_show_pagerefs = False
+
+# If true, show URL addresses after external links.
+# latex_show_urls = False
+
+# Documents to append as an appendix to all manuals.
+# latex_appendices = []
+
+# If false, no module index is generated.
+# latex_domain_indices = True
+
+
+# -- Options for manual page output ---------------------------------------
+
+# One entry per manual page. List of tuples
+# (source start file, name, description, authors, manual section).
+man_pages = [
+    (
+        "index",
+        "readthedocstemplate",
+        "Read the Docs Template Documentation",
+        ["Read the Docs"],
+        1,
+    )
+]
+
+# If true, show URL addresses after external links.
+# m an_show_urls = False
+
+
+# -- Options for Texinfo output -------------------------------------------
+
+# Grouping the document tree into Texinfo files. List of tuples
+# (source start file, target name, title, author,
+#  dir menu entry, description, category)
+texinfo_documents = [
+    (
+        "index",
+        "ReadtheDocsTemplate",
+        "Read the Docs Template Documentation",
+        "Read the Docs",
+        "ReadtheDocsTemplate",
+        "Miscellaneous",
+    ),
+]
+
+# Documents to append as an appendix to all manuals.
+# texinfo_appendices = []
+
+# If false, no module index is generated.
+# texinfo_domain_indices = True
+
+# How to display URL addresses: 'footnote', 'no', or 'inline'.
+# texinfo_show_urls = 'footnote'
+
+# If true, do not generate a @detailmenu in the "Top" node's menu.
+# texinfo_no_detailmenu = False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,9 +14,9 @@ For recommendations or bug reports, please visit https://github.com/eleanorfrajk
    :maxdepth: 2
    :caption: Getting started
 
-   installation
-   gitcollab
-   github
+   .. mdinclude:: installation.md
+   .. mdinclude:: gitcollab.md
+   .. mdinclude:: github.md
    
 .. toctree::
    :maxdepth: 3

--- a/notebooks/demo-output.ipynb
+++ b/notebooks/demo-output.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c6a29764-f39c-431c-8e77-fbc6bfe20f01",
+   "metadata": {},
+   "source": [
+    "# projectName demo\n",
+    "\n",
+    "The purpose of this notebook is to demonstrate the functionality of `projectName`.\n",
+    "\n",
+    "The demo is organised to show\n",
+    "\n",
+    "- Step 1: Explanation\n",
+    "\n",
+    "- Step 2: Explanation\n",
+    "\n",
+    "Note that when you submit a pull request, you should `clear all outputs` from your python notebook for a cleaner merge.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6a1920f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-12-01T06:29:19.878407Z",
+     "iopub.status.busy": "2024-12-01T06:29:19.878287Z",
+     "iopub.status.idle": "2024-12-01T06:29:20.746405Z",
+     "shell.execute_reply": "2024-12-01T06:29:20.746109Z"
+    }
+   },
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'pooch'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[1], line 10\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mxarray\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mxr\u001b[39;00m\n\u001b[1;32m      9\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mos\u001b[39;00m\n\u001b[0;32m---> 10\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mpooch\u001b[39;00m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mprojectName\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m readers, writers, plotters, tools, utilities\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'pooch'"
+     ]
+    }
+   ],
+   "source": [
+    "import pathlib\n",
+    "import sys\n",
+    "\n",
+    "script_dir = pathlib.Path().parent.absolute()\n",
+    "parent_dir = script_dir.parents[0]\n",
+    "sys.path.append(str(parent_dir))\n",
+    "\n",
+    "import xarray as xr\n",
+    "import os\n",
+    "import pooch\n",
+    "from projectName import readers, writers, plotters, tools, utilities\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1e070d18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-12-01T06:29:20.747857Z",
+     "iopub.status.busy": "2024-12-01T06:29:20.747753Z",
+     "iopub.status.idle": "2024-12-01T06:29:20.749288Z",
+     "shell.execute_reply": "2024-12-01T06:29:20.749040Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Specify the path for writing datafiles\n",
+    "data_path = os.path.join(parent_dir, 'data')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
The markdown files installation.md, gitcollab.md and GitHub.md were not properly included.  Now implemented as:
```
   .. mdinclude:: installation.md
   .. mdinclude:: gitcollab.md
   .. mdinclude:: github.md
```

But the docs build will be easier to test when the `docs_deploy.yml` is run upon merging a pull request.