### PR TITLE
[FIX/DOCS] Change to mdinclude in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,10 +14,10 @@ For recommendations or bug reports, please visit https://github.com/eleanorfrajk
    :maxdepth: 2
    :caption: Getting started
 
-   installation
-   gitcollab
-   github
-   
+   .. mdinclude:: installation.md
+   .. mdinclude:: gitcollab.md
+   .. mdinclude:: github.md
+         
 .. toctree::
    :maxdepth: 3
    :caption: Contents:


### PR DESCRIPTION
Markdown files aren't being included in the sphinx document build.  Changed to
```
   .. mdinclude:: installation.md
   .. mdinclude:: gitcollab.md
   .. mdinclude:: github.md
```