### PR TITLE
[DOCS] Add CITATION.cff and explainer

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: Frajka-Williams
+  given-names: Eleanor
+  orcid: https://orcid.org/0000-0001-8773-7838
+  affiliation: University of Hamburg, Bundesstraße 53, 20146 Hamburg, Germany
+title: template-project
+version: 0.0.2
+date-released: 2025-04-12
+url: https://github.com/eleanorfrajka/template-project

--- a/docs/source/citation.md
+++ b/docs/source/citation.md
@@ -1,0 +1,18 @@
+# Citable software
+
+Suppose your software project is software to be associated with a paper or as an output on a project.  To make it straightforward for people to cite it, add a [CITATION.cff](https://github.com/eleanorfrajka/template-project/blob/main/CITATION.cff) file to the root directory.  Here you can add multiple authors, refer to the version number (which should match the PyPI and GitHub version) and specify the date.
+
+For example,
+```markdown
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: Frajka-Williams
+  given-names: Eleanor
+  orcid: https://orcid.org/0000-0001-8773-7838
+  affiliation: University of Hamburg, Bundesstraße 53, 20146 Hamburg, Germany
+title: amocarray
+version: 0.0.2
+date-released: 2025-04-12
+url: https://github.com/AMOCcommunity/amocarray
+```

--- a/docs/source/citation.md
+++ b/docs/source/citation.md
@@ -16,3 +16,5 @@ version: 0.0.2
 date-released: 2025-04-12
 url: https://github.com/AMOCcommunity/amocarray
 ```
+
+Once you add this to your repository, you'll see an extra "Cite this repository" entry in the right sidebar under the **About** for the repository.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ For recommendations or bug reports, please visit https://github.com/eleanorfrajk
    github.md
    gitorg.md
    pypi-publish.md
-
+   citation.md
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION
Added an explainer for how to make the software citable.

```cff-version: 1.2.0
message: "If you use this software, please cite it as below."
authors:
- family-names: Frajka-Williams
  given-names: Eleanor
  orcid: https://orcid.org/0000-0001-8773-7838
  affiliation: University of Hamburg, Bundesstraße 53, 20146 Hamburg, Germany
title: amocarray
version: 0.0.2
date-released: 2025-04-12
url: https://github.com/AMOCcommunity/amocarray
```